### PR TITLE
Make creature strokes non-scaling.

### DIFF
--- a/lib/pages/creature-page.tsx
+++ b/lib/pages/creature-page.tsx
@@ -47,6 +47,7 @@ type AttachmentChildren = JSX.Element | JSX.Element[];
 
 type CreatureContextType = SvgSymbolContext & {
   attachmentScale: number;
+  cumulativeScale: number;
   parent: SvgSymbolData | null;
 };
 
@@ -55,6 +56,7 @@ const DEFAULT_ATTACHMENT_SCALE = 0.5;
 const CreatureContext = React.createContext<CreatureContextType>({
   ...createSvgSymbolContext(),
   attachmentScale: DEFAULT_ATTACHMENT_SCALE,
+  cumulativeScale: 1,
   parent: null,
 });
 
@@ -71,7 +73,14 @@ const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
   const ourSymbol = (
     <>
       {props.children && (
-        <CreatureContext.Provider value={{ ...ctx, parent: data }}>
+        <CreatureContext.Provider
+          value={{
+            ...ctx,
+            parent: data,
+            cumulativeScale: ctx.attachmentScale * ctx.cumulativeScale,
+            strokeScale: 1 / ctx.cumulativeScale,
+          }}
+        >
           {props.children}
         </CreatureContext.Provider>
       )}

--- a/lib/svg-symbol.tsx
+++ b/lib/svg-symbol.tsx
@@ -3,6 +3,7 @@ import { SVGProps } from "react";
 import { BBox } from "../vendor/bezier-js";
 import { FILL_REPLACEMENT_COLOR, STROKE_REPLACEMENT_COLOR } from "./colors";
 import { Specs } from "./specs";
+import { float } from "./util";
 import { VisibleSpecs } from "./visible-specs";
 
 export type SvgSymbolData = {
@@ -28,12 +29,14 @@ export type SvgSymbolElement = (
 export type SvgSymbolContext = {
   stroke: string;
   fill: string;
+  strokeScale: number;
   showSpecs: boolean;
 };
 
 const DEFAULT_CONTEXT: SvgSymbolContext = {
   stroke: "#000000",
   fill: "#ffffff",
+  strokeScale: 1,
   showSpecs: false,
 };
 
@@ -64,14 +67,18 @@ function reactifySvgSymbolElement(
   el: SvgSymbolElement,
   key: number
 ): JSX.Element {
-  let { fill, stroke } = el.props;
+  let { fill, stroke, strokeWidth } = el.props;
   fill = getColor(ctx, fill);
   stroke = getColor(ctx, stroke);
+  if (strokeWidth !== undefined) {
+    strokeWidth = float(strokeWidth) * ctx.strokeScale;
+  }
   return React.createElement(
     el.tagName,
     {
       ...el.props,
       id: undefined,
+      strokeWidth,
       fill,
       stroke,
       key,


### PR DESCRIPTION
This attempts to manually scale the strokes on creatures so they aren't affected by scale.

> ![image](https://user-images.githubusercontent.com/124687/108105633-dce08000-705a-11eb-9464-16d2de65cd95.png)

The weird thing here is that applying `vector-effect="non-scaling-stroke"` does not appear to do the trick--rather, it makes all the strokes look _super heavy_.  So in this PR we scale the stroke by the inverse of whatever we're cumulatively scaling by when we're drawing something.