### PR TITLE
Actually check TSX files with Prettier.

### DIFF
--- a/lib/svg-composition-context.tsx
+++ b/lib/svg-composition-context.tsx
@@ -26,9 +26,8 @@ export function createSvgCompositionContext(
   };
 }
 
-export type CompositionContextWidgetProps<
-  T extends SvgCompositionContext
-> = SymbolContextWidgetProps<T>;
+export type CompositionContextWidgetProps<T extends SvgCompositionContext> =
+  SymbolContextWidgetProps<T>;
 
 export function CompositionContextWidget<T extends SvgCompositionContext>({
   ctx,

--- a/lib/svg-composition-context.tsx
+++ b/lib/svg-composition-context.tsx
@@ -26,8 +26,9 @@ export function createSvgCompositionContext(
   };
 }
 
-export type CompositionContextWidgetProps<T extends SvgCompositionContext> =
-  SymbolContextWidgetProps<T>;
+export type CompositionContextWidgetProps<
+  T extends SvgCompositionContext
+> = SymbolContextWidgetProps<T>;
 
 export function CompositionContextWidget<T extends SvgCompositionContext>({
   ctx,

--- a/lib/svg-symbol-metadata.ts
+++ b/lib/svg-symbol-metadata.ts
@@ -55,9 +55,10 @@ export type SvgSymbolMetadata = SvgSymbolMetadataBooleans & {
   attach_to?: AttachmentPointType[];
 };
 
-export function validateSvgSymbolMetadata(
-  obj: any
-): { metadata: SvgSymbolMetadata; unknownProperties: string[] } {
+export function validateSvgSymbolMetadata(obj: any): {
+  metadata: SvgSymbolMetadata;
+  unknownProperties: string[];
+} {
   const metadata: SvgSymbolMetadata = {};
   const unknownProperties: string[] = [];
   for (let key in obj) {

--- a/lib/svg-symbol-metadata.ts
+++ b/lib/svg-symbol-metadata.ts
@@ -55,7 +55,9 @@ export type SvgSymbolMetadata = SvgSymbolMetadataBooleans & {
   attach_to?: AttachmentPointType[];
 };
 
-export function validateSvgSymbolMetadata(obj: any): {
+export function validateSvgSymbolMetadata(
+  obj: any
+): {
   metadata: SvgSymbolMetadata;
   unknownProperties: string[];
 } {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "deploy": "npm run build && gh-pages -d dist",
-    "prettier:check": "prettier --check lib/**/*.ts lib/**/*.ts",
-    "prettier:fix": "prettier --write   lib/**/*.ts lib/**/*.ts",
+    "prettier:check": "prettier --check lib/**/*.ts lib/**/*.tsx",
+    "prettier:fix": "prettier --write   lib/**/*.ts lib/**/*.tsx",
     "typecheck": "tsc --noemit",
     "eslint": "eslint lib --ext .ts,.tsx --max-warnings 1",
     "lint": "npm run prettier:check && npm run typecheck && npm run eslint",


### PR DESCRIPTION
This makes us actually check TSX files with Prettier (until now we were only checking TS files).

It also re-runs Prettier, although apparently it fixes something in a TS file that was raising a warning, which I find very odd--since TS files were already being checked, I'm not sure how we didn't have a broken build...