### PR TITLE
Add a 'wildcard' (neutral) attachment point type.

### DIFF
--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -13,6 +13,7 @@ export const ATTACHMENT_POINT_COLORS: {
   arm: "#00ff00",
   horn: "#00ffff",
   crown: "#0000ff",
+  wildcard: "#000000",
 };
 
 export const NESTING_BOUNDING_BOX_COLOR = "#ff00ff";

--- a/lib/pages/creature-page.tsx
+++ b/lib/pages/creature-page.tsx
@@ -64,6 +64,11 @@ const ATTACHMENT_SYMBOLS: AttachmentSymbolMap = (() => {
     result[type] = SvgVocabulary.items.filter((data) => {
       const { meta } = data;
 
+      if (type === "wildcard") {
+        // The wildcard attachment point type can have anything!
+        return true;
+      }
+
       // If we have no metadata whatsoever, it can attach anywhere.
       if (!meta) return true;
 

--- a/lib/specs.ts
+++ b/lib/specs.ts
@@ -19,6 +19,7 @@ type AttachmentPointSpecs = {
   arm: PointWithNormal[];
   horn: PointWithNormal[];
   crown: PointWithNormal[];
+  wildcard: PointWithNormal[];
 };
 
 type FullSpecs = AttachmentPointSpecs & {
@@ -41,6 +42,7 @@ export const ATTACHMENT_POINT_TYPES: AttachmentPointType[] = [
   "arm",
   "horn",
   "crown",
+  "wildcard",
 ];
 
 const ATTACHMENT_POINT_SET = new Set(ATTACHMENT_POINT_TYPES);


### PR DESCRIPTION
This adds a new attachment point type called `wildcard` (colored `#000000` in the SVGs) which, as the name suggests, can contain _any_ kind of symbol.

Fixes #187.

@ninapaley I thought "wildcard" might be a more self-evident name than "neutral" but I can change it to "neutral" if you feel strongly about that nomenclature.  Let me know what you think!