### PR TITLE
Add never_flip_attachments to TOML metadata.

### DIFF
--- a/assets/symbols/_template.toml
+++ b/assets/symbols/_template.toml
@@ -37,5 +37,11 @@ attach_to = ["tail", "leg", "arm", "horn", "crown"]
 # If true, symbol will rotate clockwise instead of default counter-clockwise
 rotate_clockwise = false
 
+# If true, this indicates that we should never horizontally flip the
+# orientation of a symbol when attaching it.  Otherwise, we will flip
+# the symbol horizontally if it's facing left, and flip it horizontally
+# again if it's facing down.
+never_flip_attachments = false
+
 # If true, symbol may be used as large background shape in some compositions.
 background = false

--- a/assets/symbols/face_nest.toml
+++ b/assets/symbols/face_nest.toml
@@ -5,5 +5,6 @@ never_be_nested = true
 
 invert_nested = true
 
+never_flip_attachments = true
 
 attach_to = []

--- a/lib/creature-symbol.tsx
+++ b/lib/creature-symbol.tsx
@@ -127,14 +127,18 @@ const AttachedCreatureSymbol: React.FC<AttachedCreatureSymbolProps> = ({
       continue;
     }
 
-    // If we're attaching something oriented towards the left, horizontally flip
-    // the attachment image.
-    let xFlip = parentAp.normal.x < 0 ? -1 : 1;
+    let xFlip = 1;
 
-    // Er, things look weird if we don't inverse the flip logic for
-    // the downward-facing attachments, like legs...
-    if (parentAp.normal.y > 0) {
-      xFlip *= -1;
+    if (!parent.meta?.never_flip_attachments) {
+      // If we're attaching something oriented towards the left, horizontally flip
+      // the attachment image.
+      xFlip = parentAp.normal.x < 0 ? -1 : 1;
+
+      // Er, things look weird if we don't inverse the flip logic for
+      // the downward-facing attachments, like legs...
+      if (parentAp.normal.y > 0) {
+        xFlip *= -1;
+      }
     }
 
     const t = getAttachmentTransforms(parentAp, {

--- a/lib/svg-symbol-metadata.ts
+++ b/lib/svg-symbol-metadata.ts
@@ -30,6 +30,14 @@ type SvgSymbolMetadataBooleans = {
    * This changes the rotation direction to clockwise.
    */
   rotate_clockwise?: boolean;
+
+  /**
+   * If true, this indicates that we should never horizontally flip the
+   * orientation of a symbol when attaching it.  Otherwise, we will flip
+   * the symbol horizontally if it's facing left, and flip it horizontally
+   * again if it's facing down.
+   */
+  never_flip_attachments?: boolean;
 };
 
 const METADATA_BOOLEANS: Set<keyof SvgSymbolMetadataBooleans> = new Set([
@@ -38,6 +46,7 @@ const METADATA_BOOLEANS: Set<keyof SvgSymbolMetadataBooleans> = new Set([
   "never_be_nested",
   "invert_nested",
   "rotate_clockwise",
+  "never_flip_attachments",
 ]);
 
 function isSvgSymbolMetadataBoolean(
@@ -55,7 +64,9 @@ export type SvgSymbolMetadata = SvgSymbolMetadataBooleans & {
   attach_to?: AttachmentPointType[];
 };
 
-export function validateSvgSymbolMetadata(obj: any): {
+export function validateSvgSymbolMetadata(
+  obj: any
+): {
   metadata: SvgSymbolMetadata;
   unknownProperties: string[];
 } {

--- a/lib/svg-symbol-metadata.ts
+++ b/lib/svg-symbol-metadata.ts
@@ -64,9 +64,7 @@ export type SvgSymbolMetadata = SvgSymbolMetadataBooleans & {
   attach_to?: AttachmentPointType[];
 };
 
-export function validateSvgSymbolMetadata(
-  obj: any
-): {
+export function validateSvgSymbolMetadata(obj: any): {
   metadata: SvgSymbolMetadata;
   unknownProperties: string[];
 } {


### PR DESCRIPTION
This adds a new `never_flip_attachments` property to TOML metadata, as discussed in #184, and sets it to `true` for the `face_nest` symbol, resulting in the following kinds of creatures:

> ![image](https://user-images.githubusercontent.com/124687/124523946-0e1dda80-ddc7-11eb-82df-c8cc4f6a4f92.png)
