### PR TITLE
Implement new Avro schema for creatures

### DIFF
--- a/lib/pages/creature-page/creature-design.avsc.json
+++ b/lib/pages/creature-page/creature-design.avsc.json
@@ -2,10 +2,6 @@
   "type": "record",
   "name": "AvroCreatureDesign",
   "fields": [
-    { "name": "randomSeed", "type": "long" },
-    { "name": "randomlyInvert", "type": "boolean" },
-    { "name": "complexity", "type": "int" },
-    { "name": "alwaysIncludeSymbol", "type": "string" },
     {
       "name": "compCtx",
       "type": {
@@ -17,6 +13,46 @@
           { "name": "background", "type": "int" },
           { "name": "uniformStrokeWidth", "type": "float" },
           { "name": "disableGradients", "type": "boolean", "default": true }
+        ]
+      }
+    },
+    {
+      "name": "creature",
+      "type": {
+        "name": "AvroCreatureSymbol",
+        "type": "record",
+        "fields": [
+          { "name": "symbol", "type": "string" },
+          { "name": "invertColors", "type": "boolean" },
+          {
+            "name": "attachments",
+            "type": {
+              "type": "array",
+              "items": {
+                "name": "AvroAttachedCreatureSymbol",
+                "type": "record",
+                "fields": [
+                  { "name": "base", "type": "AvroCreatureSymbol" },
+                  { "name": "attachTo", "type": "int" },
+                  { "name": "indices", "type": "bytes" }
+                ]
+              }
+            }
+          },
+          {
+            "name": "nests",
+            "type": {
+              "type": "array",
+              "items": {
+                "name": "AvroNestedCreatureSymbol",
+                "type": "record",
+                "fields": [
+                  { "name": "base", "type": "AvroCreatureSymbol" },
+                  { "name": "indices", "type": "bytes" }
+                ]
+              }
+            }
+          }
         ]
       }
     }

--- a/lib/pages/creature-page/serialization.ts
+++ b/lib/pages/creature-page/serialization.ts
@@ -1,24 +1,61 @@
 import * as avro from "avro-js";
 import { CreatureDesign } from "./core";
-import { AvroCreatureDesign, AvroCreatureSymbol } from "./creature-design.avsc";
+import {
+  AvroAttachedCreatureSymbol,
+  AvroCreatureDesign,
+  AvroCreatureSymbol,
+} from "./creature-design.avsc";
 import { fromBase64, toBase64 } from "../../base64";
 import CreatureAvsc from "./creature-design.avsc.json";
 import { Packer, SvgCompositionContextPacker } from "../../serialization";
-import { CreatureSymbol } from "../../creature-symbol";
+import { AttachedCreatureSymbol, CreatureSymbol } from "../../creature-symbol";
 import { SvgVocabulary } from "../../svg-vocabulary";
+import { ATTACHMENT_POINT_TYPES } from "../../specs";
 
 const LATEST_VERSION = "v2";
 
 const avroCreatureDesign = avro.parse<AvroCreatureDesign>(CreatureAvsc);
+
+const ATTACHMENT_POINT_MAPPING = new Map(
+  ATTACHMENT_POINT_TYPES.map((name, i) => {
+    return [name, i];
+  })
+);
+
+const AttachedCreatureSymbolPacker: Packer<
+  AttachedCreatureSymbol,
+  AvroAttachedCreatureSymbol
+> = {
+  pack: (value) => {
+    const attachTo = ATTACHMENT_POINT_MAPPING.get(value.attachTo);
+    if (attachTo === undefined) {
+      throw new Error(`Invalid attachment type "${value.attachTo}"`);
+    }
+    return {
+      base: CreatureSymbolPacker.pack(value),
+      attachTo,
+      indices: Buffer.from(value.indices),
+    };
+  },
+  unpack: (value) => {
+    const attachTo = ATTACHMENT_POINT_TYPES[value.attachTo];
+    if (attachTo === undefined) {
+      throw new Error(`Invalid attachment type "${value.attachTo}"`);
+    }
+    return {
+      ...CreatureSymbolPacker.unpack(value.base),
+      attachTo,
+      indices: Array.from(value.indices),
+    };
+  },
+};
 
 const CreatureSymbolPacker: Packer<CreatureSymbol, AvroCreatureSymbol> = {
   pack: (value) => {
     return {
       ...value,
       symbol: value.data.name,
-
-      // TODO: Implement this!
-      attachments: [],
+      attachments: value.attachments.map(AttachedCreatureSymbolPacker.pack),
       nests: [],
     };
   },
@@ -26,9 +63,7 @@ const CreatureSymbolPacker: Packer<CreatureSymbol, AvroCreatureSymbol> = {
     return {
       ...value,
       data: SvgVocabulary.get(value.symbol),
-
-      // TODO: Implement this!
-      attachments: [],
+      attachments: value.attachments.map(AttachedCreatureSymbolPacker.unpack),
       nests: [],
     };
   },


### PR DESCRIPTION
The creature state stored in #210, while quite compact, is also very fragile, because any minor change in our creature generation algorithm or even vocabulary will completely throw off existing serializations.

This attempts to serialize the actual _creature_ created by the generator rather than its random number seed, which will be a larger serialization but also one that is more resilient to future changes in the algorithm and/or vocabulary.  It should also pave the way for tweaking generated creatures.

Note that the previous `v1` schema implemented in #210 is no longer supported--i.e., links that use it will now be broken.  Hopefully this is OK because it hasn't been around for very long, but it was just way too much work to migrate that schema to the new `v2` format.

## To do

- [x] Serialize/deserialize attached and nested symbols.
- [ ] See if we can potentially preserve the non-serialized generator parameters as the user navigates through their browser history.  (Currently, going back will reset a bunch of parameters to their defaults, which is not ideal.)