### PR TITLE
Gallery thumbnails

### DIFF
--- a/lib/loading-indicator.css
+++ b/lib/loading-indicator.css
@@ -7,7 +7,7 @@
 }
 
 .loading-indicator svg {
-  width: 25%;
-  height: 25%;
+  width: 64px;
+  height: 64px;
   fill: lightgray;
 }

--- a/lib/loading-indicator.css
+++ b/lib/loading-indicator.css
@@ -1,0 +1,13 @@
+.loading-indicator {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loading-indicator svg {
+  width: 25%;
+  height: 25%;
+  fill: lightgray;
+}

--- a/lib/loading-indicator.tsx
+++ b/lib/loading-indicator.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+import "./loading-indicator.css";
+
+/**
+ * Loading indicator taken from:
+ *
+ * https://commons.wikimedia.org/wiki/File:Chromiumthrobber.svg
+ */
+export const LoadingIndicator: React.FC = () => (
+  <div className="loading-indicator">
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 300 300"
+      xmlns="http://www.w3.org/2000/svg"
+      version="1.1"
+    >
+      <path
+        d="M 150,0
+           a 150,150 0 0,1 106.066,256.066
+           l -35.355,-35.355
+           a -100,-100 0 0,0 -70.711,-170.711 z"
+      >
+        <animateTransform
+          attributeName="transform"
+          attributeType="XML"
+          type="rotate"
+          from="0 150 150"
+          to="360 150 150"
+          begin="0s"
+          dur="1s"
+          fill="freeze"
+          repeatCount="indefinite"
+        />
+      </path>
+    </svg>
+  </div>
+);

--- a/lib/pages/gallery-page.css
+++ b/lib/pages/gallery-page.css
@@ -1,0 +1,19 @@
+.gallery-thumbnail {
+  width: 320px;
+  height: 240px;
+}
+
+.gallery-thumbnail.is-empty {
+  background-color: lightgray;
+}
+
+.gallery-item {
+  display: inline-block;
+  border: 1px solid black;
+  margin-right: 1em;
+  margin-bottom: 1em;
+}
+
+.gallery-item p {
+  margin: 1em;
+}

--- a/lib/pages/gallery-page.css
+++ b/lib/pages/gallery-page.css
@@ -3,8 +3,17 @@
   height: 240px;
 }
 
+.gallery-item > a {
+  text-decoration: none;
+}
+
 .gallery-thumbnail.is-empty {
   background-color: lightgray;
+}
+
+.gallery-thumbnail.is-empty > span {
+  color: darkgray;
+  font-size: 48px;
 }
 
 .gallery-item {

--- a/lib/pages/gallery-page.tsx
+++ b/lib/pages/gallery-page.tsx
@@ -5,7 +5,11 @@ import {
   CreatureContextType,
   CreatureSymbol,
 } from "../creature-symbol";
-import { GalleryComposition, GalleryContext } from "../gallery-context";
+import {
+  GalleryComposition,
+  GalleryCompositionKind,
+  GalleryContext,
+} from "../gallery-context";
 import { Page } from "../page";
 import { createPageWithStateSearchParams } from "../page-with-shareable-state";
 import { svgScale, SvgTransform } from "../svg-transform";
@@ -78,27 +82,28 @@ const MandalaThumbnail: React.FC<{ design: MandalaDesign }> = (props) => {
   );
 };
 
+const THUMBNAILERS: {
+  [key in GalleryCompositionKind]: (gc: GalleryComposition) => JSX.Element;
+} = {
+  creature: (gc) => (
+    <CreatureThumbnail design={deserializeCreatureDesign(gc.serializedValue)} />
+  ),
+  mandala: (gc) => (
+    <MandalaThumbnail design={deserializeMandalaDesign(gc.serializedValue)} />
+  ),
+};
+
 function getThumbnail(gc: GalleryComposition): JSX.Element {
-  if (gc.kind === "creature") {
-    let design: CreatureDesign;
+  if (gc.kind in THUMBNAILERS) {
     try {
-      design = deserializeCreatureDesign(gc.serializedValue);
+      return THUMBNAILERS[gc.kind](gc);
     } catch (e) {
-      console.log(`Could not deserialize creature "${gc.title}"`, e);
-      return <EmptyThumbnail />;
+      console.log(`Could not deserialize ${gc.kind} "${gc.title}"`, e);
     }
-    return <CreatureThumbnail design={design} />;
+  } else {
+    console.log(`Found unknown gallery composition kind "${gc.kind}".`);
   }
-  if (gc.kind === "mandala") {
-    let design: MandalaDesign;
-    try {
-      design = deserializeMandalaDesign(gc.serializedValue);
-    } catch (e) {
-      console.log(`Could not deserialize creature "${gc.title}"`, e);
-      return <EmptyThumbnail />;
-    }
-    return <MandalaThumbnail design={design} />;
-  }
+
   return <EmptyThumbnail />;
 }
 

--- a/lib/pages/gallery-page.tsx
+++ b/lib/pages/gallery-page.tsx
@@ -146,7 +146,7 @@ export const GalleryPage: React.FC<{}> = () => {
   return (
     <Page title="Gallery!">
       <div className="sidebar">
-        <p>
+        <p style={{ marginTop: "0" }}>
           You can publish to this gallery via the sidebar on other pages of this
           site.
         </p>

--- a/lib/pages/gallery-page.tsx
+++ b/lib/pages/gallery-page.tsx
@@ -34,8 +34,10 @@ const THUMBNAIL_CLASS = "gallery-thumbnail canvas";
 
 const THUMBNAIL_SCALE = 0.2;
 
-const EmptyThumbnail: React.FC = () => (
-  <div className={THUMBNAIL_CLASS + " is-empty"}></div>
+const ErrorThumbnail: React.FC<{ title?: string }> = ({ title }) => (
+  <div className={THUMBNAIL_CLASS + " is-empty"} title={title}>
+    <span>☹</span>
+  </div>
 );
 
 const CreatureThumbnail: React.FC<{ design: CreatureDesign }> = (props) => {
@@ -94,17 +96,22 @@ const THUMBNAILERS: {
 };
 
 function getThumbnail(gc: GalleryComposition): JSX.Element {
+  let errorTitle: string;
+
   if (gc.kind in THUMBNAILERS) {
     try {
       return THUMBNAILERS[gc.kind](gc);
     } catch (e) {
-      console.log(`Could not deserialize ${gc.kind} "${gc.title}"`, e);
+      errorTitle = `Could not deserialize ${gc.kind} "${gc.title}".`;
+      console.error(e);
     }
   } else {
-    console.log(`Found unknown gallery composition kind "${gc.kind}".`);
+    errorTitle = `Found unknown gallery composition kind "${gc.kind}".`;
   }
 
-  return <EmptyThumbnail />;
+  console.log(errorTitle);
+
+  return <ErrorThumbnail title={errorTitle} />;
 }
 
 const GalleryCompositionView: React.FC<GalleryComposition> = (props) => {

--- a/lib/pages/gallery-page.tsx
+++ b/lib/pages/gallery-page.tsx
@@ -1,7 +1,18 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useRef } from "react";
+import { AutoSizingSvg } from "../auto-sizing-svg";
+import {
+  CreatureContext,
+  CreatureContextType,
+  CreatureSymbol,
+} from "../creature-symbol";
 import { GalleryComposition, GalleryContext } from "../gallery-context";
 import { Page } from "../page";
 import { createPageWithStateSearchParams } from "../page-with-shareable-state";
+import { svgScale, SvgTransform } from "../svg-transform";
+import { CreatureDesign } from "./creature-page/core";
+import { deserializeCreatureDesign } from "./creature-page/serialization";
+
+import "./gallery-page.css";
 
 function compositionRemixUrl(comp: GalleryComposition): string {
   return (
@@ -10,14 +21,63 @@ function compositionRemixUrl(comp: GalleryComposition): string {
   );
 }
 
-const GalleryCompositionView: React.FC<GalleryComposition> = (props) => {
+const THUMBNAIL_CLASS = "gallery-thumbnail canvas";
+
+const EmptyThumbnail: React.FC = () => (
+  <div className={THUMBNAIL_CLASS + " is-empty"}></div>
+);
+
+const CreatureThumbnail: React.FC<{ design: CreatureDesign }> = (props) => {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const ctx: CreatureContextType = {
+    ...useContext(CreatureContext),
+    ...props.design.compCtx,
+  };
+  const { background } = props.design.compCtx;
+
   return (
-    <p>
-      <a href={compositionRemixUrl(props)} target="_blank">
-        {props.title}
-      </a>{" "}
-      {props.kind} by {props.ownerName}
-    </p>
+    <div className={THUMBNAIL_CLASS} style={{ backgroundColor: background }}>
+      <CreatureContext.Provider value={ctx}>
+        <AutoSizingSvg padding={10} ref={svgRef} bgColor={background}>
+          <SvgTransform transform={svgScale(0.2)}>
+            <CreatureSymbol {...props.design.creature} />
+          </SvgTransform>
+        </AutoSizingSvg>
+      </CreatureContext.Provider>
+    </div>
+  );
+};
+
+function getThumbnail(gc: GalleryComposition): JSX.Element {
+  if (gc.kind === "creature") {
+    let design: CreatureDesign;
+    try {
+      design = deserializeCreatureDesign(gc.serializedValue);
+    } catch (e) {
+      console.log(`Could not deserialize creature "${gc.title}"`, e);
+      return <EmptyThumbnail />;
+    }
+    return <CreatureThumbnail design={design} />;
+  }
+  return <EmptyThumbnail />;
+}
+
+const GalleryCompositionView: React.FC<GalleryComposition> = (props) => {
+  const thumbnail = getThumbnail(props);
+  const url = compositionRemixUrl(props);
+
+  return (
+    <div className="gallery-item">
+      <a href={url} target="_blank">
+        {thumbnail}
+      </a>
+      <p>
+        <a href={url} target="_blank">
+          {props.title}
+        </a>{" "}
+        {props.kind} by {props.ownerName}
+      </p>
+    </div>
   );
 };
 

--- a/lib/pages/gallery-page.tsx
+++ b/lib/pages/gallery-page.tsx
@@ -34,9 +34,8 @@ export const GalleryPage: React.FC<{}> = () => {
     <Page title="Gallery!">
       <div className="sidebar">
         <p>
-          This gallery is a work in progress! You can publish to it via the
-          sidebar on the creature and mandala pages. We don't have thumbnails
-          yet, though. It will improve over time.
+          You can publish to this gallery via the sidebar on other pages of this
+          site.
         </p>
         <button onClick={ctx.refresh} disabled={ctx.isLoading}>
           {ctx.isLoading ? "Loading\u2026" : "Refresh"}

--- a/lib/pages/gallery-page.tsx
+++ b/lib/pages/gallery-page.tsx
@@ -102,7 +102,7 @@ function getThumbnail(gc: GalleryComposition): JSX.Element {
     try {
       return THUMBNAILERS[gc.kind](gc);
     } catch (e) {
-      errorTitle = `Could not deserialize ${gc.kind} "${gc.title}".`;
+      errorTitle = `Could not deserialize ${gc.kind} "${gc.title}": ${e.message}`;
       console.error(e);
     }
   } else {

--- a/lib/pages/gallery-page.tsx
+++ b/lib/pages/gallery-page.tsx
@@ -10,6 +10,7 @@ import {
   GalleryCompositionKind,
   GalleryContext,
 } from "../gallery-context";
+import { LoadingIndicator } from "../loading-indicator";
 import { Page } from "../page";
 import { createPageWithStateSearchParams } from "../page-with-shareable-state";
 import { svgScale, SvgTransform } from "../svg-transform";
@@ -155,9 +156,13 @@ export const GalleryPage: React.FC<{}> = () => {
         {ctx.error && <p className="error">{ctx.error}</p>}
       </div>
       <div className="canvas scrollable">
-        {ctx.compositions.map((comp) => (
-          <GalleryCompositionView key={comp.id} {...comp} />
-        ))}
+        {ctx.isLoading ? (
+          <LoadingIndicator />
+        ) : (
+          ctx.compositions.map((comp) => (
+            <GalleryCompositionView key={comp.id} {...comp} />
+          ))
+        )}
       </div>
     </Page>
   );

--- a/lib/pages/mandala-page/core.tsx
+++ b/lib/pages/mandala-page/core.tsx
@@ -226,14 +226,17 @@ function isDesignAnimated(design: MandalaDesign): boolean {
   return getCirclesFromDesign(design).some((c) => c.animateSymbolRotation);
 }
 
-function createAnimationRenderer({
-  baseCompCtx,
-  invertCircle2,
-  circle1,
-  circle2,
-  useTwoCircles,
-  firstBehind,
-}: MandalaDesign): AnimationRenderer {
+export function createMandalaAnimationRenderer(
+  {
+    baseCompCtx,
+    invertCircle2,
+    circle1,
+    circle2,
+    useTwoCircles,
+    firstBehind,
+  }: MandalaDesign,
+  scale = 0.5
+): AnimationRenderer {
   const symbolCtx = noFillIfShowingSpecs(baseCompCtx);
   const circle2SymbolCtx = invertCircle2 ? swapColors(symbolCtx) : symbolCtx;
 
@@ -259,7 +262,7 @@ function createAnimationRenderer({
       }
     }
 
-    return <SvgTransform transform={svgScale(0.5)}>{circles}</SvgTransform>;
+    return <SvgTransform transform={svgScale(scale)}>{circles}</SvgTransform>;
   };
 }
 
@@ -336,7 +339,10 @@ export const MandalaPageWithDefaults: React.FC<{
     ]
   );
   const isAnimated = isDesignAnimated(design);
-  const render = useMemo(() => createAnimationRenderer(design), [design]);
+  const render = useMemo(
+    () => createMandalaAnimationRenderer(design),
+    [design]
+  );
 
   useDebouncedEffect(
     250,


### PR DESCRIPTION
This adds thumbnails to the gallery (#26).  Mandalas are not currently animated (I'm worried that doing this for lots of mandalas would severely impact performance).  It also adds a loading throbber for the gallery page.

> ![image](https://user-images.githubusercontent.com/124687/131346239-a514d164-ce26-494f-a31c-c2c5c8e29ecf.png)

If a gallery item can't be deserialized, a sad face is shown in place of a thumbnail, with a more detailed explanation on mouseover. For example, if our "clock" symbol were to disappear from our vocabulary (which hopefully won't happen if we do deprecation right, see #221), this would happen (the mouse cursor is at the top-left of the tooltip but was not captured in the screenshot):

> ![image](https://user-images.githubusercontent.com/124687/131682382-f9eca8f4-acd6-4d5f-8c45-c3a87e9eb314.png)

Currently the implementation is not as clean as I'd like.  I'll clean it up in a separate PR, as it will involve factoring out logic from the creature and mandala pages (similar in concept to #189 / #190), which would add lots of noise to this diff.