### PR TITLE
Show error modal if deserialization fails.

### DIFF
--- a/lib/page-with-shareable-state.tsx
+++ b/lib/page-with-shareable-state.tsx
@@ -50,6 +50,9 @@ const DeserializationErrorModal: React.FC = () => {
 
   if (!show) return null;
 
+  // TODO: This isn't accessible at all; it ought to trap keyboard focus,
+  // disappear when the user presses ESC, and so on.
+
   return (
     <div className="page-error">
       <div>

--- a/lib/page-with-shareable-state.tsx
+++ b/lib/page-with-shareable-state.tsx
@@ -84,13 +84,15 @@ export function createPageWithShareableState<T>({
      */
     const [isInOnChange, setIsInOnChange] = useState(false);
 
-    /** The default state from th URL, which we'll pass into our component. */
+    /** The default state from the URL, which we'll pass into our component. */
     let defaults: T = defaultValue;
+    let deserializeError = false;
 
     try {
       defaults = deserialize(state || "");
     } catch (e) {
       console.log(`Error deserializing state: ${e}`);
+      deserializeError = true;
     }
 
     const onChange = useCallback(
@@ -115,7 +117,26 @@ export function createPageWithShareableState<T>({
       }
     }, [isInOnChange, state, latestState, key]);
 
-    return <Component key={key} defaults={defaults} onChange={onChange} />;
+    return (
+      <>
+        {deserializeError && (
+          <div className="page-error">
+            <div>
+              <p>
+                Sorry, an error occurred when trying to load the composition on
+                this page.
+              </p>
+              <p>
+                Either its data is corrupted, or displaying it is no longer
+                supported.
+              </p>
+              <button>Alas</button>
+            </div>
+          </div>
+        )}
+        <Component key={key} defaults={defaults} onChange={onChange} />
+      </>
+    );
   };
 
   return PageWithShareableState;

--- a/lib/page-with-shareable-state.tsx
+++ b/lib/page-with-shareable-state.tsx
@@ -86,14 +86,16 @@ export function createPageWithShareableState<T>({
 
     /** The default state from the URL, which we'll pass into our component. */
     let defaults: T = defaultValue;
-    let deserializeError = false;
+    let didDeserializeThrow = false;
 
     try {
       defaults = deserialize(state || "");
     } catch (e) {
       console.log(`Error deserializing state: ${e}`);
-      deserializeError = true;
+      didDeserializeThrow = true;
     }
+
+    const [showError, setShowError] = useState(didDeserializeThrow);
 
     const onChange = useCallback(
       (value: T) => {
@@ -119,7 +121,7 @@ export function createPageWithShareableState<T>({
 
     return (
       <>
-        {deserializeError && (
+        {showError && (
           <div className="page-error">
             <div>
               <p>
@@ -130,7 +132,7 @@ export function createPageWithShareableState<T>({
                 Either its data is corrupted, or displaying it is no longer
                 supported.
               </p>
-              <button>Alas</button>
+              <button onClick={() => setShowError(false)}>OK</button>
             </div>
           </div>
         )}

--- a/lib/page-with-shareable-state.tsx
+++ b/lib/page-with-shareable-state.tsx
@@ -45,6 +45,27 @@ export function createPageWithStateSearchParams(
   return search;
 }
 
+const DeserializationErrorModal: React.FC = () => {
+  const [show, setShow] = useState(true);
+
+  if (!show) return null;
+
+  return (
+    <div className="page-error">
+      <div>
+        <p>
+          Sorry, an error occurred when trying to load the composition on this
+          page.
+        </p>
+        <p>
+          Either its data is corrupted, or displaying it is no longer supported.
+        </p>
+        <button onClick={() => setShow(false)}>OK</button>
+      </div>
+    </div>
+  );
+};
+
 /**
  * Create a component that represents a page which exposes some
  * aspect of its state in the current URL, so that it can be
@@ -86,6 +107,7 @@ export function createPageWithShareableState<T>({
 
     /** The default state from the URL, which we'll pass into our component. */
     let defaults: T = defaultValue;
+
     let didDeserializeThrow = false;
 
     try {
@@ -94,8 +116,6 @@ export function createPageWithShareableState<T>({
       console.log(`Error deserializing state: ${e}`);
       didDeserializeThrow = true;
     }
-
-    const [showError, setShowError] = useState(didDeserializeThrow);
 
     const onChange = useCallback(
       (value: T) => {
@@ -121,21 +141,7 @@ export function createPageWithShareableState<T>({
 
     return (
       <>
-        {showError && (
-          <div className="page-error">
-            <div>
-              <p>
-                Sorry, an error occurred when trying to load the composition on
-                this page.
-              </p>
-              <p>
-                Either its data is corrupted, or displaying it is no longer
-                supported.
-              </p>
-              <button onClick={() => setShowError(false)}>OK</button>
-            </div>
-          </div>
-        )}
+        {didDeserializeThrow && <DeserializationErrorModal />}
         <Component key={key} defaults={defaults} onChange={onChange} />
       </>
     );

--- a/lib/page.css
+++ b/lib/page.css
@@ -116,3 +116,39 @@ ul.navbar li:last-child {
 .error {
   color: red;
 }
+
+.page-error {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  background-color: rgba(0, 0, 0, 0.75);
+}
+
+.page-error div {
+  background: crimson;
+  color: white;
+  padding: 2em;
+  max-width: 50em;
+  pointer-events: auto;
+}
+
+.page-error div p:first-child {
+  margin-top: 0;
+}
+
+.page-error div p:last-child {
+  margin-bottom: 0;
+}
+
+.page-error div button {
+  display: block;
+  width: 66%;
+  margin: 3em auto 0 auto;
+  text-align: center;
+}

--- a/lib/page.css
+++ b/lib/page.css
@@ -126,7 +126,6 @@ ul.navbar li:last-child {
   display: flex;
   align-items: center;
   justify-content: center;
-  pointer-events: none;
   background-color: rgba(0, 0, 0, 0.75);
 }
 
@@ -135,7 +134,6 @@ ul.navbar li:last-child {
   color: white;
   padding: 2em;
   max-width: 50em;
-  pointer-events: auto;
 }
 
 .page-error div p:first-child {


### PR DESCRIPTION
This fixes #213.  It is not particularly accessible, but since it (hopefully) shouldn't be displayed too often, I'm going to merge it anyways for now--better an inaccessible modal than failing silently.

Screenshot:

> ![image](https://user-images.githubusercontent.com/124687/134573882-d9e969f7-bab9-49bd-a99c-700d68c6cf51.png)
