### PR TITLE
Add a black & white button.

### DIFF
--- a/lib/svg-composition-context.tsx
+++ b/lib/svg-composition-context.tsx
@@ -40,7 +40,12 @@ export function CompositionContextWidget<T extends SvgCompositionContext>({
   };
   const extraButtons = (
     <>
-      <button onClick={resetColors}>B&amp;W</button>{" "}
+      <button
+        onClick={resetColors}
+        title="Reset colors to their black &amp; white defaults"
+      >
+        B&amp;W
+      </button>{" "}
     </>
   );
   return (

--- a/lib/svg-composition-context.tsx
+++ b/lib/svg-composition-context.tsx
@@ -34,8 +34,21 @@ export function CompositionContextWidget<T extends SvgCompositionContext>({
   onChange,
   children,
 }: CompositionContextWidgetProps<T>): JSX.Element {
+  const resetColors = () => {
+    const { background, stroke, fill } = DEFAULT_CONTEXT;
+    onChange({ ...ctx, background, stroke, fill });
+  };
+  const extraButtons = (
+    <>
+      <button onClick={resetColors}>B&amp;W</button>{" "}
+    </>
+  );
   return (
-    <SymbolContextWidget ctx={ctx} onChange={onChange}>
+    <SymbolContextWidget
+      ctx={ctx}
+      onChange={onChange}
+      extraButtons={extraButtons}
+    >
       {children}
       <ColorWidget
         label="Background"


### PR DESCRIPTION
This adds a "B&W" button to the colors area in the cluster and mandala pages. Clicking it will reset the background, stroke and fill colors to their monochromatic defaults.

> ![image](https://user-images.githubusercontent.com/124687/134903300-5ffcbc27-b499-4e31-8dfc-e5cd76649483.png)

I'm calling the button "B&W" for now to minimize the amount of space the button takes up, since I'd like to add at least one more to that area.  At some point we might want to use a UI that scales a bit better, like a dropdown button.
