### PR TITLE
Add a 'mono' button.

### DIFF
--- a/lib/svg-composition-context.tsx
+++ b/lib/svg-composition-context.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { mixColor } from "./color-util";
 import { ColorWidget } from "./color-widget";
 import { DEFAULT_BG_COLOR } from "./colors";
 import { createSvgSymbolContext, SvgSymbolContext } from "./svg-symbol";
@@ -38,6 +39,13 @@ export function CompositionContextWidget<T extends SvgCompositionContext>({
     const { background, stroke, fill } = DEFAULT_CONTEXT;
     onChange({ ...ctx, background, stroke, fill });
   };
+  const monochromatizeColors = () => {
+    onChange({
+      ...ctx,
+      stroke: mixColor(ctx.background, DEFAULT_CONTEXT.stroke, 0.1),
+      fill: mixColor(ctx.background, DEFAULT_CONTEXT.fill, 0.1),
+    });
+  };
   const extraButtons = (
     <>
       <button
@@ -45,6 +53,12 @@ export function CompositionContextWidget<T extends SvgCompositionContext>({
         title="Reset colors to their black &amp; white defaults"
       >
         B&amp;W
+      </button>{" "}
+      <button
+        onClick={monochromatizeColors}
+        title="Make stroke and fill a variation of the background"
+      >
+        Mono
       </button>{" "}
     </>
   );


### PR DESCRIPTION
This adds another color-modifying button, "Mono", which makes the fill and stroke colors a minor variation of the background. This makes the composition as a whole monochromatic, hence the name. (Err, at least I _think_ that's an accurate word for what's being done, let me know if I'm wrong!)

> ![image](https://user-images.githubusercontent.com/124687/134908302-bb344459-bf77-4cda-8979-a316659080fc.png)

Here's an example of a design before pressing the button:

> ![mystic-symbolic-creature-rain](https://user-images.githubusercontent.com/124687/134906379-27a1d8f2-b5bf-4049-8122-16eb6885ba62.png)

And here's what it looks like after:

> ![mystic-symbolic-creature-rain(1)](https://user-images.githubusercontent.com/124687/134906413-8b17b99e-74e7-485f-89f1-0694e721af03.png)

In practice, this is just tinting the background by black (stroke) and white (fill) a tiny bit.  The color transformation could be used, for instance, to turn a cluster (even a simple one that is essentially just a single symbol) into a background for another cluster. (Note that there's not currently an easy way to actually compose multiple compositions like this, though I'd like there to be!)

@ninapaley is this the kind of effect you were thinking of, when you described having a very low-contrast symbol be the background for a cluster/mandala?