### PR TITLE
Add cluster animations.

### DIFF
--- a/lib/auto-sizing-svg.tsx
+++ b/lib/auto-sizing-svg.tsx
@@ -3,8 +3,21 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 type AutoSizingSvgProps = {
   padding?: number;
   bgColor?: string;
+
+  /**
+   * A ref to an element that we resize the SVG dimensions
+   * to match. If not provided, we'll just use the bounding
+   * box of the SVG itself.
+   */
   sizeToElement?: React.RefObject<HTMLElement>;
+
+  /**
+   * Whenever this key changes, we'll resize the SVG. If
+   * it's undefined, we will use `props.children` as
+   * the key.
+   */
   resizeKey?: any;
+
   children: JSX.Element | JSX.Element[];
 };
 

--- a/lib/auto-sizing-svg.tsx
+++ b/lib/auto-sizing-svg.tsx
@@ -4,6 +4,7 @@ type AutoSizingSvgProps = {
   padding?: number;
   bgColor?: string;
   sizeToElement?: React.RefObject<HTMLElement>;
+  resizeKey?: any;
   children: JSX.Element | JSX.Element[];
 };
 
@@ -45,10 +46,14 @@ export const AutoSizingSvg = React.forwardRef(
 
     useResizeHandler(resizeToElement);
 
-    // Note that we're passing `props.children` in as a dependency; it's not
-    // used anywhere in the effect, but since any change to the
-    // children may result in a dimension change in the SVG element, we
-    // want it to trigger the effect.
+    // This is an "artificial" effect dependency that isn't used anywhere in
+    // our effect, but is used to determine when our effect is triggered.
+    // By default, since any change to `props.children` may result in a
+    // dimension change in the SVG element, we want it to trigger the effect,
+    // but alternatively our caller can tell us when to resize via
+    // `props.resizeKey` too.
+    const resizeDependency = props.resizeKey ?? props.children;
+
     useEffect(() => {
       if (!resizeToElement()) {
         const svgEl = gRef.current;
@@ -61,7 +66,7 @@ export const AutoSizingSvg = React.forwardRef(
           setHeight(bbox.height + padding * 2);
         }
       }
-    }, [props.padding, resizeToElement, props.children]);
+    }, [props.padding, resizeToElement, resizeDependency]);
 
     return (
       <svg

--- a/lib/creature-animator.tsx
+++ b/lib/creature-animator.tsx
@@ -9,7 +9,6 @@ import {
 
 type AnimationTransformer = (
   animPct: number,
-  animScale: number,
   symbol: SvgSymbolData
 ) => SvgTransform[];
 
@@ -50,15 +49,13 @@ function pctToNegativeOneToOne(pct: number) {
 
 const Y_HOVER_AMPLITUDE = 25.0;
 
-const hoverTransformer: AnimationTransformer = (animPct, animScale) => {
+const hoverTransformer: AnimationTransformer = (animPct) => {
   const yHover =
-    pctToNegativeOneToOne(easeInOutQuadPingPong(animPct)) *
-    Y_HOVER_AMPLITUDE *
-    animScale;
+    pctToNegativeOneToOne(easeInOutQuadPingPong(animPct)) * Y_HOVER_AMPLITUDE;
   return [svgTranslate({ x: 0, y: yHover })];
 };
 
-const spinTransformer: AnimationTransformer = (animPct, animScale, symbol) => {
+const spinTransformer: AnimationTransformer = (animPct, symbol) => {
   const origin = getBoundingBoxCenter(symbol.bbox);
   return [svgTransformOrigin(origin, [svgRotate(animPct * 360)])];
 };

--- a/lib/creature-animator.tsx
+++ b/lib/creature-animator.tsx
@@ -67,7 +67,7 @@ const spinAnimator: CreatureAnimator = {
 
 export const CREATURE_ANIMATOR_NAMES = ["none", "breathe", "spin"] as const;
 
-type CreatureAnimatorName = typeof CREATURE_ANIMATOR_NAMES[number];
+export type CreatureAnimatorName = typeof CREATURE_ANIMATOR_NAMES[number];
 
 export const CreatureAnimators: {
   [k in CreatureAnimatorName]: CreatureAnimator;

--- a/lib/creature-animator.tsx
+++ b/lib/creature-animator.tsx
@@ -60,22 +60,28 @@ const animateSpin: CreatureAnimate = (animPct, symbol) => {
   return [svgTransformOrigin(origin, [svgRotate(animPct * 360)])];
 };
 
-export const hoverAnimator: CreatureAnimator = {
-  animate: animateHover,
-  getChildAnimator: () => hoverAnimator,
-};
-
 const spinAnimator: CreatureAnimator = {
   animate: animateSpin,
   getChildAnimator: () => spinAnimator,
 };
 
-export const hoverAndSpinAnimator: CreatureAnimator = {
-  animate: animateHover,
-  getChildAnimator: () => spinAnimator,
-};
+export const CREATURE_ANIMATOR_NAMES = ["none", "breathe", "spin"] as const;
 
-export const nullAnimator: CreatureAnimator = {
-  animate: () => [],
-  getChildAnimator: () => nullAnimator,
+type CreatureAnimatorName = typeof CREATURE_ANIMATOR_NAMES[number];
+
+export const CreatureAnimators: {
+  [k in CreatureAnimatorName]: CreatureAnimator;
+} = {
+  none: {
+    animate: () => [],
+    getChildAnimator: () => CreatureAnimators.none,
+  },
+  breathe: {
+    animate: animateHover,
+    getChildAnimator: () => CreatureAnimators.breathe,
+  },
+  spin: {
+    animate: animateHover,
+    getChildAnimator: () => spinAnimator,
+  },
 };

--- a/lib/creature-animator.tsx
+++ b/lib/creature-animator.tsx
@@ -1,0 +1,84 @@
+import { getBoundingBoxCenter } from "./bounding-box";
+import { SvgSymbolData } from "./svg-symbol";
+import {
+  svgRotate,
+  SvgTransform,
+  svgTransformOrigin,
+  svgTranslate,
+} from "./svg-transform";
+
+type AnimationTransformer = (
+  animPct: number,
+  animScale: number,
+  symbol: SvgSymbolData
+) => SvgTransform[];
+
+export interface CreatureAnimator {
+  getSvgTransforms: AnimationTransformer;
+  getChildAnimator(): CreatureAnimator;
+}
+
+/**
+ * Any function that takes a number in the range [0, 1] and
+ * transforms it to a number in the same range, for the
+ * purposes of animation easing.
+ */
+type EasingFunction = (t: number) => number;
+
+// https://gist.github.com/gre/1650294
+const easeInOutQuad: EasingFunction = (t) =>
+  t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+
+/**
+ * Ease from 0, get to 1 by the time t=0.5, and then
+ * ease back to 0.
+ */
+const easeInOutQuadPingPong: EasingFunction = (t) => {
+  if (t < 0.5) {
+    return easeInOutQuad(t * 2);
+  }
+  return 1 - easeInOutQuad((t - 0.5) * 2);
+};
+
+/**
+ * Convert a percentage (number in the range [0, 1]) to
+ * a number in the range [-1, 1].
+ */
+function pctToNegativeOneToOne(pct: number) {
+  return (pct - 0.5) * 2;
+}
+
+const Y_HOVER_AMPLITUDE = 25.0;
+
+const hoverTransformer: AnimationTransformer = (animPct, animScale) => {
+  const yHover =
+    pctToNegativeOneToOne(easeInOutQuadPingPong(animPct)) *
+    Y_HOVER_AMPLITUDE *
+    animScale;
+  return [svgTranslate({ x: 0, y: yHover })];
+};
+
+const spinTransformer: AnimationTransformer = (animPct, animScale, symbol) => {
+  const origin = getBoundingBoxCenter(symbol.bbox);
+  return [svgTransformOrigin(origin, [svgRotate(animPct * 360)])];
+};
+
+export const hoverAnimator: CreatureAnimator = {
+  getSvgTransforms: hoverTransformer,
+  getChildAnimator: () => hoverAnimator,
+};
+
+const spinAnimator: CreatureAnimator = {
+  getSvgTransforms: spinTransformer,
+  getChildAnimator: () => spinAnimator,
+};
+
+export const hoverAndSpinAnimator: CreatureAnimator = {
+  getSvgTransforms: hoverTransformer,
+  getChildAnimator: () => spinAnimator,
+};
+
+export const nullAnimator: CreatureAnimator = {
+  getSvgTransforms: () => [],
+  getChildAnimator: () => nullAnimator,
+};

--- a/lib/creature-animator.tsx
+++ b/lib/creature-animator.tsx
@@ -7,13 +7,13 @@ import {
   svgTranslate,
 } from "./svg-transform";
 
-type AnimationTransformer = (
+type CreatureAnimate = (
   animPct: number,
   symbol: SvgSymbolData
 ) => SvgTransform[];
 
 export interface CreatureAnimator {
-  getSvgTransforms: AnimationTransformer;
+  animate: CreatureAnimate;
   getChildAnimator(): CreatureAnimator;
 }
 
@@ -49,33 +49,33 @@ function pctToNegativeOneToOne(pct: number) {
 
 const Y_HOVER_AMPLITUDE = 25.0;
 
-const hoverTransformer: AnimationTransformer = (animPct) => {
+const animateHover: CreatureAnimate = (animPct) => {
   const yHover =
     pctToNegativeOneToOne(easeInOutQuadPingPong(animPct)) * Y_HOVER_AMPLITUDE;
   return [svgTranslate({ x: 0, y: yHover })];
 };
 
-const spinTransformer: AnimationTransformer = (animPct, symbol) => {
+const animateSpin: CreatureAnimate = (animPct, symbol) => {
   const origin = getBoundingBoxCenter(symbol.bbox);
   return [svgTransformOrigin(origin, [svgRotate(animPct * 360)])];
 };
 
 export const hoverAnimator: CreatureAnimator = {
-  getSvgTransforms: hoverTransformer,
+  animate: animateHover,
   getChildAnimator: () => hoverAnimator,
 };
 
 const spinAnimator: CreatureAnimator = {
-  getSvgTransforms: spinTransformer,
+  animate: animateSpin,
   getChildAnimator: () => spinAnimator,
 };
 
 export const hoverAndSpinAnimator: CreatureAnimator = {
-  getSvgTransforms: hoverTransformer,
+  animate: animateHover,
   getChildAnimator: () => spinAnimator,
 };
 
 export const nullAnimator: CreatureAnimator = {
-  getSvgTransforms: () => [],
+  animate: () => [],
   getChildAnimator: () => nullAnimator,
 };

--- a/lib/creature-animator.tsx
+++ b/lib/creature-animator.tsx
@@ -7,13 +7,23 @@ import {
   svgTranslate,
 } from "./svg-transform";
 
+/**
+ * A type of function that tells us how to transform a creature based
+ * on how far through an animation we are.
+ */
 type CreatureAnimate = (
   animPct: number,
   symbol: SvgSymbolData
 ) => SvgTransform[];
 
+/**
+ * A strategy for animating a creature.
+ */
 export interface CreatureAnimator {
+  /** How to animate the main body of the creature. */
   animate: CreatureAnimate;
+
+  /** How to animate the children (attachments & nests) of the creature. */
   getChildAnimator(): CreatureAnimator;
 }
 

--- a/lib/creature-symbol.tsx
+++ b/lib/creature-symbol.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useMemo } from "react";
 import { BBox, Point } from "../vendor/bezier-js";
 import { getAttachmentTransforms } from "./attach";
 import { getBoundingBoxCenter, uniformlyScaleToFit } from "./bounding-box";
-import { CreatureAnimator, nullAnimator } from "./creature-animator";
+import { CreatureAnimator, CreatureAnimators } from "./creature-animator";
 import { scalePointXY, subtractPoints } from "./point";
 import { AttachmentPointType } from "./specs";
 import {
@@ -218,7 +218,7 @@ export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
   let ctx = useContext(CreatureContext);
   const { data, attachments, nests } = props;
   const attachmentCtx: CreatureContextType = { ...ctx, parent: data };
-  const animator = props.animator ?? nullAnimator;
+  const animator = props.animator ?? CreatureAnimators.none;
   const animPct = props.animPct ?? 0;
   const svgTransforms = useMemo(
     () => animator.animate(animPct, data),

--- a/lib/creature-symbol.tsx
+++ b/lib/creature-symbol.tsx
@@ -53,21 +53,18 @@ export type CreatureSymbol = {
 export type CreatureSymbolProps = CreatureSymbol & {
   animator?: CreatureAnimator;
   animPct?: number;
-  animScale?: number;
 };
 
 type NestedCreatureSymbolProps = NestedCreatureSymbol & {
   parent: SvgSymbolData;
   animator: CreatureAnimator;
   animPct: number;
-  animScale: number;
 };
 
 type AttachedCreatureSymbolProps = AttachedCreatureSymbol & {
   parent: SvgSymbolData;
   animator: CreatureAnimator;
   animPct: number;
-  animScale: number;
 };
 
 function getNestingTransforms(parent: BBox, child: BBox) {
@@ -217,18 +214,15 @@ const NestedCreatureSymbol: React.FC<NestedCreatureSymbolProps> = ({
   return <>{children}</>;
 };
 
-const CHILD_ANIM_SCALE_MULTIPLIER = 0.5;
-
 export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
   let ctx = useContext(CreatureContext);
   const { data, attachments, nests } = props;
   const attachmentCtx: CreatureContextType = { ...ctx, parent: data };
   const animator = props.animator ?? nullAnimator;
   const animPct = props.animPct ?? 0;
-  const animScale = props.animScale ?? 1;
   const svgTransforms = useMemo(
-    () => animator.getSvgTransforms(animPct, animScale, data),
-    [animator, animPct, animScale, data]
+    () => animator.getSvgTransforms(animPct, data),
+    [animator, animPct, data]
   );
   const childAnimator = useMemo(() => animator.getChildAnimator(), [animator]);
 
@@ -253,7 +247,6 @@ export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
               {...a}
               parent={data}
               animPct={animPct}
-              animScale={animScale * CHILD_ANIM_SCALE_MULTIPLIER}
               animator={childAnimator}
             />
           ))}
@@ -268,7 +261,6 @@ export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
               {...n}
               parent={data}
               animPct={animPct}
-              animScale={animScale * CHILD_ANIM_SCALE_MULTIPLIER}
               animator={childAnimator}
             />
           ))}

--- a/lib/creature-symbol.tsx
+++ b/lib/creature-symbol.tsx
@@ -49,19 +49,24 @@ export type CreatureSymbol = {
   nests: NestedCreatureSymbol[];
 };
 
+type AnimationType = "hover" | "rotate";
+
 export type CreatureSymbolProps = CreatureSymbol & {
+  animType?: AnimationType;
   animPct?: number;
   animScale?: number;
 };
 
 type NestedCreatureSymbolProps = NestedCreatureSymbol & {
   parent: SvgSymbolData;
+  animType: AnimationType;
   animPct: number;
   animScale: number;
 };
 
 type AttachedCreatureSymbolProps = AttachedCreatureSymbol & {
   parent: SvgSymbolData;
+  animType: AnimationType;
   animPct: number;
   animScale: number;
 };
@@ -250,12 +255,18 @@ export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
   let ctx = useContext(CreatureContext);
   const { data, attachments, nests } = props;
   const attachmentCtx: CreatureContextType = { ...ctx, parent: data };
+  const animType = props.animType ?? "hover";
   const animPct = props.animPct ?? 0;
   const animScale = props.animScale ?? 1;
   const yHover =
     pctToNegativeOneToOne(easeInOutQuadPingPong(animPct)) *
     Y_HOVER_AMPLITUDE *
     animScale;
+  const origin = getBoundingBoxCenter(data.bbox);
+  const svgTransforms =
+    animType === "hover"
+      ? [svgTranslate({ x: 0, y: yHover })]
+      : [svgRotate(animPct * 360)];
 
   if (props.invertColors) {
     ctx = swapColors(ctx);
@@ -269,7 +280,7 @@ export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
   // appear behind our symbol, while anything nested within our symbol
   // should be after our symbol so they appear in front of it.
   return (
-    <SvgTransform transform={[svgTranslate({ x: 0, y: yHover })]}>
+    <SvgTransform transform={[svgTransformOrigin(origin, svgTransforms)]}>
       {attachments.length && (
         <CreatureContext.Provider value={attachmentCtx}>
           {attachments.map((a, i) => (
@@ -279,6 +290,7 @@ export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
               parent={data}
               animPct={animPct}
               animScale={animScale * CHILD_ANIM_SCALE_MULTIPLIER}
+              animType="rotate"
             />
           ))}
         </CreatureContext.Provider>
@@ -293,6 +305,7 @@ export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
               parent={data}
               animPct={animPct}
               animScale={animScale * CHILD_ANIM_SCALE_MULTIPLIER}
+              animType="rotate"
             />
           ))}
         </CreatureContext.Provider>

--- a/lib/creature-symbol.tsx
+++ b/lib/creature-symbol.tsx
@@ -221,7 +221,7 @@ export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
   const animator = props.animator ?? nullAnimator;
   const animPct = props.animPct ?? 0;
   const svgTransforms = useMemo(
-    () => animator.getSvgTransforms(animPct, data),
+    () => animator.animate(animPct, data),
     [animator, animPct, data]
   );
   const childAnimator = useMemo(() => animator.getChildAnimator(), [animator]);

--- a/lib/creature-symbol.tsx
+++ b/lib/creature-symbol.tsx
@@ -51,14 +51,19 @@ export type CreatureSymbol = {
 
 export type CreatureSymbolProps = CreatureSymbol & {
   animPct?: number;
+  animScale?: number;
 };
 
 type NestedCreatureSymbolProps = NestedCreatureSymbol & {
   parent: SvgSymbolData;
+  animPct: number;
+  animScale: number;
 };
 
 type AttachedCreatureSymbolProps = AttachedCreatureSymbol & {
   parent: SvgSymbolData;
+  animPct: number;
+  animScale: number;
 };
 
 function getNestingTransforms(parent: BBox, child: BBox) {
@@ -238,12 +243,19 @@ function pctToNegativeOneToOne(pct: number) {
   return (pct - 0.5) * 2;
 }
 
+const Y_HOVER_AMPLITUDE = 25.0;
+const CHILD_ANIM_SCALE_MULTIPLIER = 0.5;
+
 export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
   let ctx = useContext(CreatureContext);
   const { data, attachments, nests } = props;
   const attachmentCtx: CreatureContextType = { ...ctx, parent: data };
+  const animPct = props.animPct ?? 0;
+  const animScale = props.animScale ?? 1;
   const yHover =
-    pctToNegativeOneToOne(easeInOutQuadPingPong(props.animPct || 0)) * 25.0;
+    pctToNegativeOneToOne(easeInOutQuadPingPong(animPct)) *
+    Y_HOVER_AMPLITUDE *
+    animScale;
 
   if (props.invertColors) {
     ctx = swapColors(ctx);
@@ -261,7 +273,13 @@ export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
       {attachments.length && (
         <CreatureContext.Provider value={attachmentCtx}>
           {attachments.map((a, i) => (
-            <AttachedCreatureSymbol key={i} {...a} parent={data} />
+            <AttachedCreatureSymbol
+              key={i}
+              {...a}
+              parent={data}
+              animPct={animPct}
+              animScale={animScale * CHILD_ANIM_SCALE_MULTIPLIER}
+            />
           ))}
         </CreatureContext.Provider>
       )}
@@ -269,7 +287,13 @@ export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
       {nests.length && (
         <CreatureContext.Provider value={nestedCtx}>
           {nests.map((n, i) => (
-            <NestedCreatureSymbol key={i} {...n} parent={data} />
+            <NestedCreatureSymbol
+              key={i}
+              {...n}
+              parent={data}
+              animPct={animPct}
+              animScale={animScale * CHILD_ANIM_SCALE_MULTIPLIER}
+            />
           ))}
         </CreatureContext.Provider>
       )}

--- a/lib/creature-symbol.tsx
+++ b/lib/creature-symbol.tsx
@@ -208,12 +208,21 @@ const NestedCreatureSymbol: React.FC<NestedCreatureSymbolProps> = ({
   return <>{children}</>;
 };
 
+/**
+ * Any function that takes a number in the range [0, 1] and
+ * transforms it to a number in the same range, for the
+ * purposes of animation easing.
+ */
 type EasingFunction = (t: number) => number;
 
 // https://gist.github.com/gre/1650294
 const easeInOutQuad: EasingFunction = (t) =>
   t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
 
+/**
+ * Ease from 0, get to 1 by the time t=0.5, and then
+ * ease back to 0.
+ */
 const easeInOutQuadPingPong: EasingFunction = (t) => {
   if (t < 0.5) {
     return easeInOutQuad(t * 2);
@@ -221,12 +230,20 @@ const easeInOutQuadPingPong: EasingFunction = (t) => {
   return 1 - easeInOutQuad((t - 0.5) * 2);
 };
 
+/**
+ * Convert a percentage (number in the range [0, 1]) to
+ * a number in the range [-1, 1].
+ */
+function pctToNegativeOneToOne(pct: number) {
+  return (pct - 0.5) * 2;
+}
+
 export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
   let ctx = useContext(CreatureContext);
   const { data, attachments, nests } = props;
   const attachmentCtx: CreatureContextType = { ...ctx, parent: data };
-  const animPct = easeInOutQuadPingPong(props.animPct || 0);
-  const y = animPct * 50.0;
+  const yHover =
+    pctToNegativeOneToOne(easeInOutQuadPingPong(props.animPct || 0)) * 25.0;
 
   if (props.invertColors) {
     ctx = swapColors(ctx);
@@ -240,7 +257,7 @@ export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
   // appear behind our symbol, while anything nested within our symbol
   // should be after our symbol so they appear in front of it.
   return (
-    <SvgTransform transform={[svgTranslate({ x: 0, y })]}>
+    <SvgTransform transform={[svgTranslate({ x: 0, y: yHover })]}>
       {attachments.length && (
         <CreatureContext.Provider value={attachmentCtx}>
           {attachments.map((a, i) => (

--- a/lib/pages/creature-page/core.tsx
+++ b/lib/pages/creature-page/core.tsx
@@ -47,7 +47,7 @@ import { GalleryWidget } from "../../gallery-widget";
 import { serializeCreatureDesign } from "./serialization";
 import { CreatureEditorWidget } from "./creature-editor";
 import { useAnimationPct } from "../../animation";
-import { hoverAndSpinAnimator } from "../../creature-animator";
+import { CreatureAnimators } from "../../creature-animator";
 
 /**
  * The minimum number of attachment points that any symbol used as the main body
@@ -384,7 +384,7 @@ function createCreatureAnimationRenderer(
           <CreatureSymbol
             {...creature}
             animPct={animPct}
-            animator={hoverAndSpinAnimator}
+            animator={CreatureAnimators.spin}
           />
         </CreatureContext.Provider>
       </SvgTransform>

--- a/lib/pages/creature-page/core.tsx
+++ b/lib/pages/creature-page/core.tsx
@@ -47,6 +47,7 @@ import { GalleryWidget } from "../../gallery-widget";
 import { serializeCreatureDesign } from "./serialization";
 import { CreatureEditorWidget } from "./creature-editor";
 import { useAnimationPct } from "../../animation";
+import { hoverAndSpinAnimator } from "../../creature-animator";
 
 /**
  * The minimum number of attachment points that any symbol used as the main body
@@ -380,7 +381,11 @@ function createCreatureAnimationRenderer(
     return (
       <SvgTransform transform={svgScale(scale)}>
         <CreatureContext.Provider value={ctx}>
-          <CreatureSymbol {...creature} animPct={animPct} />
+          <CreatureSymbol
+            {...creature}
+            animPct={animPct}
+            animator={hoverAndSpinAnimator}
+          />
         </CreatureContext.Provider>
       </SvgTransform>
     );

--- a/lib/pages/creature-page/core.tsx
+++ b/lib/pages/creature-page/core.tsx
@@ -396,20 +396,15 @@ const ANIMATION_PERIOD_MS = 5000;
 
 const CreatureCanvas = React.forwardRef<SVGSVGElement, CreatureCanvasProps>(
   ({ compCtx, render }, svgRef) => {
-    const canvasRef = useRef<HTMLDivElement | null>(null);
     const animPct = useAnimationPct(ANIMATION_PERIOD_MS);
 
     return (
-      <div
-        className="canvas"
-        style={{ backgroundColor: compCtx.background }}
-        ref={canvasRef}
-      >
+      <div className="canvas" style={{ backgroundColor: compCtx.background }}>
         <HoverDebugHelper>
           <AutoSizingSvg
-            padding={20}
+            padding={100}
             ref={svgRef}
-            sizeToElement={canvasRef}
+            resizeKey={render}
             bgColor={compCtx.background}
           >
             {render(animPct)}

--- a/lib/pages/creature-page/core.tsx
+++ b/lib/pages/creature-page/core.tsx
@@ -304,6 +304,7 @@ export const CreaturePageWithDefaults: React.FC<
       "creature-page:animatorName",
       "none"
     );
+  const isAnimated = animatorName !== "none";
   const [randomlyInvert, setRandomlyInvert] = useRememberedState(
     "creature-page:randomlyInvert",
     true
@@ -399,11 +400,16 @@ export const CreaturePageWithDefaults: React.FC<
           <ExportWidget
             basename={getDownloadBasename(creature.data.name)}
             svgRef={svgRef}
-            animate={{ duration: ANIMATION_PERIOD_MS, render }}
+            animate={isAnimated && { duration: ANIMATION_PERIOD_MS, render }}
           />
         </div>
       </div>
-      <CreatureCanvas compCtx={compCtx} render={render} ref={svgRef} />
+      <CreatureCanvas
+        compCtx={compCtx}
+        render={render}
+        ref={svgRef}
+        isAnimated={isAnimated}
+      />
     </Page>
   );
 };
@@ -430,6 +436,7 @@ function createCreatureAnimationRenderer(
 }
 
 type CreatureCanvasProps = {
+  isAnimated: boolean;
   compCtx: SvgCompositionContext;
   render: AnimationRenderer;
 };
@@ -437,8 +444,8 @@ type CreatureCanvasProps = {
 const ANIMATION_PERIOD_MS = 5000;
 
 const CreatureCanvas = React.forwardRef<SVGSVGElement, CreatureCanvasProps>(
-  ({ compCtx, render }, svgRef) => {
-    const animPct = useAnimationPct(ANIMATION_PERIOD_MS);
+  ({ isAnimated, compCtx, render }, svgRef) => {
+    const animPct = useAnimationPct(isAnimated ? ANIMATION_PERIOD_MS : 0);
 
     return (
       <div className="canvas" style={{ backgroundColor: compCtx.background }}>

--- a/lib/pages/creature-page/core.tsx
+++ b/lib/pages/creature-page/core.tsx
@@ -46,6 +46,7 @@ import { useRememberedState } from "../../use-remembered-state";
 import { GalleryWidget } from "../../gallery-widget";
 import { serializeCreatureDesign } from "./serialization";
 import { CreatureEditorWidget } from "./creature-editor";
+import { useAnimationPct } from "../../animation";
 
 /**
  * The minimum number of attachment points that any symbol used as the main body
@@ -377,17 +378,25 @@ type CreatureCanvasProps = {
 
 const CreatureCanvas = React.forwardRef<SVGSVGElement, CreatureCanvasProps>(
   ({ compCtx, ctx, creature }, svgRef) => {
+    const canvasRef = useRef<HTMLDivElement | null>(null);
+    const animPct = useAnimationPct(5000);
+
     return (
-      <div className="canvas" style={{ backgroundColor: compCtx.background }}>
+      <div
+        className="canvas"
+        style={{ backgroundColor: compCtx.background }}
+        ref={canvasRef}
+      >
         <CreatureContext.Provider value={ctx}>
           <HoverDebugHelper>
             <AutoSizingSvg
               padding={20}
               ref={svgRef}
+              sizeToElement={canvasRef}
               bgColor={compCtx.background}
             >
               <SvgTransform transform={svgScale(0.5)}>
-                <CreatureSymbol {...creature} />
+                <CreatureSymbol {...creature} animPct={animPct} />
               </SvgTransform>
             </AutoSizingSvg>
           </HoverDebugHelper>


### PR DESCRIPTION
This is a hackneyed attempt to add simple animations to clusters.

I nabbed some nice easing functions from [this venerable gist](https://gist.github.com/gre/1650294).

![mystic-symbolic-creature-poot](https://user-images.githubusercontent.com/124687/147678748-c81244d1-52ca-4503-a68e-ab5219c0bdfd.gif)

## To do

- [x] Right now there's really just one hard-coded animation that's applied to all clusters. We should figure out something better.
