### PR TITLE
Serialize cluster animator.

### DIFF
--- a/lib/creature-animator.tsx
+++ b/lib/creature-animator.tsx
@@ -75,9 +75,25 @@ const spinAnimator: CreatureAnimator = {
   getChildAnimator: () => spinAnimator,
 };
 
+/**
+ * Names of all the animators.
+ *
+ * Note that this list should never be re-ordered, as the index of
+ * each animator corresponds to its animator id.
+ */
 export const CREATURE_ANIMATOR_NAMES = ["none", "breathe", "spin"] as const;
 
 export type CreatureAnimatorName = typeof CREATURE_ANIMATOR_NAMES[number];
+
+export function creatureAnimatorNameToId(name: CreatureAnimatorName): number {
+  return CREATURE_ANIMATOR_NAMES.indexOf(name);
+}
+
+export function creatureAnimatorIdToName(
+  id: number
+): CreatureAnimatorName | undefined {
+  return CREATURE_ANIMATOR_NAMES[id];
+}
 
 export const CreatureAnimators: {
   [k in CreatureAnimatorName]: CreatureAnimator;

--- a/lib/pages/creature-page/core.tsx
+++ b/lib/pages/creature-page/core.tsx
@@ -256,11 +256,13 @@ function repeatUntilSymbolIsIncluded(
 }
 
 export type CreatureDesign = {
+  animatorName: CreatureAnimatorName;
   compCtx: SvgCompositionContext;
   creature: CreatureSymbol;
 };
 
 export const CREATURE_DESIGN_DEFAULTS: CreatureDesign = {
+  animatorName: "none",
   compCtx: createSvgCompositionContext(),
   creature: {
     data: ROOT_SYMBOLS[0],
@@ -279,7 +281,7 @@ const AnimationWidget: React.FC<AnimationWidgetProps> = (props) => {
   const id = "animationName";
   return (
     <div className="flex-widget thingy">
-      <label htmlFor={id}>Animation (experimental):</label>
+      <label htmlFor={id}>Animation:</label>
       <select
         id={id}
         onChange={(e) => props.onChange(e.target.value as CreatureAnimatorName)}
@@ -299,11 +301,7 @@ export const CreaturePageWithDefaults: React.FC<
   ComponentWithShareableStateProps<CreatureDesign>
 > = ({ defaults, onChange }) => {
   const svgRef = useRef<SVGSVGElement>(null);
-  const [animatorName, setAnimatorName] =
-    useRememberedState<CreatureAnimatorName>(
-      "creature-page:animatorName",
-      "none"
-    );
+  const [animatorName, setAnimatorName] = useState(defaults.animatorName);
   const isAnimated = animatorName !== "none";
   const [randomlyInvert, setRandomlyInvert] = useRememberedState(
     "creature-page:randomlyInvert",
@@ -339,10 +337,11 @@ export const CreaturePageWithDefaults: React.FC<
   );
   const design: CreatureDesign = useMemo(
     () => ({
+      animatorName,
       creature,
       compCtx,
     }),
-    [creature, compCtx]
+    [creature, compCtx, animatorName]
   );
 
   useDebouncedEffect(

--- a/lib/pages/creature-page/creature-design.v2.avsc.json
+++ b/lib/pages/creature-page/creature-design.v2.avsc.json
@@ -3,11 +3,6 @@
   "name": "AvroCreatureDesign",
   "fields": [
     {
-      "name": "animatorId",
-      "type": "int",
-      "default": 0
-    },
-    {
       "name": "compCtx",
       "type": {
         "name": "AvroSvgCompositionContext",

--- a/lib/pages/creature-page/serialization.test.ts
+++ b/lib/pages/creature-page/serialization.test.ts
@@ -1,0 +1,23 @@
+import {
+  serializeCreatureDesign,
+  deserializeCreatureDesign,
+} from "./serialization";
+import { CREATURE_DESIGN_DEFAULTS } from "./core";
+
+describe("Mandala design serialization/desrialization", () => {
+  // Helper to make it easy for us to copy/paste from URLs.
+  const decodeAndDeserialize = (s: string) =>
+    deserializeCreatureDesign(decodeURIComponent(s));
+
+  it("deserializes from v2", () => {
+    const design = decodeAndDeserialize(
+      "v2.gIiJA%2BqfB4bA0wwAAIA%2FABpleWVfc3RhcmJ1cnN0AAQKY2xvY2sAAAAIBAABEGluZmluaXR5AQAAAgIAAAIUc3Blcm1fdGFpbAEAAAIAAA%3D%3D"
+    );
+    expect(design.animatorName).toBe("none");
+  });
+
+  it("works", () => {
+    const s = serializeCreatureDesign(CREATURE_DESIGN_DEFAULTS);
+    expect(deserializeCreatureDesign(s)).toEqual(CREATURE_DESIGN_DEFAULTS);
+  });
+});


### PR DESCRIPTION
In #232, cluster animations were added, but they weren't serialized as part of the cluster design, which meant that sharing them wouldn't copy over the animation.  This fixes that.

This also removes "(experimental)" from the animation widget label.